### PR TITLE
Implement sample MCP server and agent

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3.8"
+services:
+  mongo:
+    image: mongo:7
+    restart: unless-stopped
+    ports:
+      - "27017:27017"
+    volumes:
+      - ./data:/data/db

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "mcp-todo",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/server.js"
+  }
+}

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,0 +1,27 @@
+import { spawn } from "node:child_process";
+import OpenAI from "openai";
+import { McpClient } from "@modelcontextprotocol/sdk/client/mcp.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+(async () => {
+  const server = spawn("node", ["./dist/server.js"], { stdio: ["pipe","pipe","inherit"] });
+  const client = new McpClient();
+  await client.connect(new StdioClientTransport(server.stdin!, server.stdout!));
+
+  const llm = new OpenAI();
+  const user = process.argv.slice(2).join(" ");
+  const sys = `あなたはタスク分解アシスタント。
+JSON で {"title": "..."} 配列のみ返してください (最大5件)。`;
+
+  const rsp = await llm.chat.completions.create({
+    model: "gpt-4o",
+    messages: [{ role: "system", content: sys }, { role: "user", content: user }],
+    response_format: { type: "json_object" }
+  });
+  const todos: { title: string }[] = JSON.parse(rsp.choices[0].message.content ?? "");
+
+  for (const t of todos) await client.callTool("todo.create", t);
+
+  console.log("\ud83d\udccc Added TODOs:", todos);
+  server.kill();
+})();

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,0 +1,5 @@
+import { MongoClient } from "mongodb";
+
+const uri = process.env.MONGO_URI ?? "mongodb://localhost:27017";
+export const dbPromise = new MongoClient(uri).connect()
+  .then(c => c.db(process.env.DB_NAME ?? "mcp_todo"));

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,34 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import { ObjectId } from "mongodb";
+import { dbPromise } from "./db.js";
+
+const db = await dbPromise;
+const todos = db.collection<{
+  _id: ObjectId; title: string; done: boolean; createdAt: Date;
+}>("todos");
+
+const server = new McpServer({ name: "Todo MCP Server", version: "0.1.0" });
+
+server.tool(
+  "todo.create",
+  z.object({ title: z.string().min(1) }),
+  async ({ title }) => {
+    const doc = { _id: new ObjectId(), title, done: false, createdAt: new Date() };
+    await todos.insertOne(doc);
+    return { content: [{ type: "json", json: doc }] };
+  },
+  { description: "Create a new TODO item from title text" }
+);
+
+server.resource(
+  "todo://list",
+  async () => {
+    const list = await todos.find().sort({ createdAt: -1 }).toArray();
+    return { contents: list.map(t => ({ uri: `todo://${t._id}`, text: JSON.stringify(t) })) };
+  },
+  { description: "Return all current TODO items" }
+);
+
+await server.connect(new StdioServerTransport());

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- set up TypeScript project configuration
- add docker compose with MongoDB
- implement MongoDB-backed MCP server
- implement agent that talks to the server

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'mongodb', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68457a234c3883268e5ecfee4278af84