### PR TITLE
Add testable server and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ OPENAI_API_KEY=あなたのキー node dist/agent.js "買い物の準備をす�
 これにより TODO 項目が作成され、完了後に表示されます。
 
 
+## テスト
+
+Node.js 組み込みのテストランナーで簡単なユニットテストを実行できます:
+
+```bash
+npm test
+```
+
 ## 環境変数
 
 - `OPENAI_API_KEY` – OpenAI の API キー

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "build": "tsc",
-    "start": "node dist/server.js"
+    "start": "node dist/server.js",
+    "test": "npm run build && node --test"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,38 +1,68 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
-type Todo = { id: number; title: string; done: boolean; createdAt: Date };
-const todos: Todo[] = [];
-let nextId = 1;
+import { fileURLToPath } from "node:url";
 
-const server = new McpServer({ name: "Todo MCP Server", version: "0.1.0" });
+export type Todo = { id: number; title: string; done: boolean; createdAt: Date };
 
-server.registerTool(
-  "todo.create",
-  {
-    description: "Create a new TODO item from title text",
-    inputSchema: { title: z.string().min(1) }
-  },
-  async ({ title }) => {
+export function createTodoServer() {
+  const todos: Todo[] = [];
+  let nextId = 1;
+
+  const server = new McpServer({ name: "Todo MCP Server", version: "0.1.0" });
+
+  const create = async ({ title }: { title: string }) => {
     const doc: Todo = { id: nextId++, title, done: false, createdAt: new Date() };
     todos.push(doc);
-    return {
-      content: [{ type: "text", text: JSON.stringify(doc) }],
-      structuredContent: doc
-    };
-  }
-);
+    return doc;
+  };
 
-server.resource(
-  "todo.list",
-  "todo://list",
-  { description: "Return all current TODO items" },
-  async () => {
-    const list = [...todos].sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
-    return {
-      contents: list.map(t => ({ uri: `todo://${t.id}`, text: JSON.stringify(t) }))
-    };
-  }
-);
+  const list = async () => {
+    return [...todos].sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+  };
 
-await server.connect(new StdioServerTransport());
+  server.registerTool(
+    "todo.create",
+    {
+      description: "Create a new TODO item from title text",
+      inputSchema: { title: z.string().min(1) }
+    },
+    async ({ title }) => {
+      const doc = await create({ title });
+      return {
+        content: [{ type: "text", text: JSON.stringify(doc) }],
+        structuredContent: doc
+      };
+    }
+  );
+
+  server.resource(
+    "todo.list",
+    "todo://list",
+    { description: "Return all current TODO items" },
+    async () => {
+      const listResult = await list();
+      return {
+        contents: listResult.map(t => ({ uri: `todo://${t.id}`, text: JSON.stringify(t) }))
+      };
+    }
+  );
+
+  return {
+    server,
+    todos,
+    create,
+    list,
+    async start() {
+      await server.connect(new StdioServerTransport());
+    },
+    async stop() {
+      await server.close();
+    }
+  };
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const { start } = createTodoServer();
+  await start();
+}

--- a/test/todo.test.js
+++ b/test/todo.test.js
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createTodoServer } from '../dist/server.js';
+
+// Verify todo.create adds items
+
+test('todo.create adds items', async () => {
+  const { create, list } = createTodoServer();
+  let items = await list();
+  assert.equal(items.length, 0);
+
+  await create({ title: 'first' });
+  items = await list();
+  assert.equal(items.length, 1);
+  assert.equal(items[0].title, 'first');
+});
+
+// Verify todo.list returns items sorted by creation date
+
+test('todo.list returns them sorted by creation date', async () => {
+  const { create, list } = createTodoServer();
+  await create({ title: 'one' });
+  // Ensure second item has later timestamp
+  await new Promise(r => setTimeout(r, 10));
+  await create({ title: 'two' });
+
+  const items = await list();
+  assert.equal(items.length, 2);
+  assert.equal(items[0].title, 'two');
+  assert.equal(items[1].title, 'one');
+});


### PR DESCRIPTION
## Summary
- expose `createTodoServer` to start/stop the MCP server
- add unit tests with Node's built-in test runner
- document `npm test` usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68458e4b8604832693607d8ee4196ef8